### PR TITLE
Fix dialog styleUrls and refactor style manager

### DIFF
--- a/src/app/components/dialogs/kofi-dialog/kofi-dialog.component.ts
+++ b/src/app/components/dialogs/kofi-dialog/kofi-dialog.component.ts
@@ -3,6 +3,6 @@ import { Component } from '@angular/core';
 @Component({
     selector: 'app-kofi-dialog',
     templateUrl: './kofi-dialog.component.html',
-    styleUrl: './kofi-dialog.component.scss'
+    styleUrls: ['./kofi-dialog.component.scss']
 })
 export class KofiDialogComponent {}

--- a/src/app/services/style-manager.service.ts
+++ b/src/app/services/style-manager.service.ts
@@ -13,7 +13,7 @@ export class StyleManagerService {
    * Set the stylesheet with the specified key.
    */
   setStyle(key: string, href: string) {
-    getLinkElementForKey1(key).setAttribute('href', href);
+    getLinkElementForKey(key).setAttribute('href', href);
   }
 
   /**
@@ -38,7 +38,7 @@ export class StyleManagerService {
   }
 }
 
-function getLinkElementForKey1(key: string) {
+function getLinkElementForKey(key: string) {
   return getExistingLinkElementByKey(key) || createLinkElementWithKey(key);
 }
 


### PR DESCRIPTION
## Summary
- fix typo on dialog styleUrls property
- rename getLinkElementForKey1 to getLinkElementForKey

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684592bf6fe88330ae4da0e444eeee2e