### PR TITLE
Fix kofi dialog styles array

### DIFF
--- a/src/app/components/dialogs/kofi-dialog/kofi-dialog.component.ts
+++ b/src/app/components/dialogs/kofi-dialog/kofi-dialog.component.ts
@@ -3,6 +3,6 @@ import { Component } from '@angular/core';
 @Component({
     selector: 'app-kofi-dialog',
     templateUrl: './kofi-dialog.component.html',
-    styleUrl: './kofi-dialog.component.scss'
+    styleUrls: ['./kofi-dialog.component.scss']
 })
 export class KofiDialogComponent {}


### PR DESCRIPTION
## Summary
- use the `styleUrls` array in `KofiDialogComponent`

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684594d355e48330a10966fa66778045