### PR TITLE
Fix invalid hex codes

### DIFF
--- a/src/app/components/landing/landing.component.html
+++ b/src/app/components/landing/landing.component.html
@@ -174,7 +174,7 @@
             subtitle="Backend in 1 file, for when you need a quick backend"
             imagePath="pocketbase"
             url="https://pocketbase.io/"
-            rippleColor="#FFFFF40"
+            rippleColor="#FFFFFF40"
           >
           </app-tech-card>
         </div>
@@ -251,7 +251,7 @@
             subtitle="Backend in 1 file, for when you need a quick backend"
             imagePath="pocketbase"
             url="https://pocketbase.io/"
-            rippleColor="#FFFFF40"
+            rippleColor="#FFFFFF40"
           >
           </app-tech-card>
           <app-tech-card


### PR DESCRIPTION
## Summary
- fix invalid hex codes for tech card ripples

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run lint --silent` *(fails: couldn't find eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_684594d1ecf48330b9f059af6cda42bc